### PR TITLE
Updated to spconv==1.1

### DIFF
--- a/pcdet/datasets/dataset.py
+++ b/pcdet/datasets/dataset.py
@@ -152,8 +152,10 @@ class DatasetTemplate(torch_data.Dataset):
         if cfg.DATA_CONFIG[self.mode].SHUFFLE_POINTS:
             np.random.shuffle(points)
 
+        voxel_grid = self.voxel_generator.generate(points, max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS)
         voxels, coordinates, num_points = \
-            self.voxel_generator.generate(points, max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS)
+            voxel_grid["voxels"], voxel_grid["coordinates"], voxel_grid["num_points_per_voxel"]
+
 
         voxel_centers = (coordinates[:, ::-1] + 0.5) * self.voxel_generator.voxel_size \
                         + self.voxel_generator.point_cloud_range[0:3]

--- a/pcdet/datasets/dataset.py
+++ b/pcdet/datasets/dataset.py
@@ -152,11 +152,15 @@ class DatasetTemplate(torch_data.Dataset):
         if cfg.DATA_CONFIG[self.mode].SHUFFLE_POINTS:
             np.random.shuffle(points)
 
-        voxel_grid = self.voxel_generator.generate(
-            points, max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS)
-        voxels, coordinates, num_points = \
-            voxel_grid["voxels"], voxel_grid["coordinates"], voxel_grid["num_points_per_voxel"]
+        voxel_grid = self.voxel_generator.generate(points)
 
+        # Support spconv 1.0 and 1.1
+        try:
+            voxels, coordinates, num_points = voxel_grid
+        except:
+            voxels = voxel_grid["voxels"]
+            coordinates = voxel_grid["coordinates"]
+            num_points = voxel_grid["num_points_per_voxel"]
 
         voxel_centers = (coordinates[:, ::-1] + 0.5) * self.voxel_generator.voxel_size \
                         + self.voxel_generator.point_cloud_range[0:3]

--- a/pcdet/datasets/dataset.py
+++ b/pcdet/datasets/dataset.py
@@ -152,7 +152,8 @@ class DatasetTemplate(torch_data.Dataset):
         if cfg.DATA_CONFIG[self.mode].SHUFFLE_POINTS:
             np.random.shuffle(points)
 
-        voxel_grid = self.voxel_generator.generate(points, max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS)
+        voxel_grid = self.voxel_generator.generate(
+            points, max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS)
         voxels, coordinates, num_points = \
             voxel_grid["voxels"], voxel_grid["coordinates"], voxel_grid["num_points_per_voxel"]
 

--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -10,7 +10,7 @@ from pcdet.utils import box_utils, object3d_utils, calibration, common_utils
 from pcdet.ops.roiaware_pool3d import roiaware_pool3d_utils
 from pcdet.config import cfg
 from pcdet.datasets.data_augmentation.dbsampler import DataBaseSampler
-from spconv.utils import VoxelGenerator
+from spconv.utils import VoxelGeneratorV2
 from pcdet.datasets import DatasetTemplate
 
 

--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -6,11 +6,12 @@ import numpy as np
 from skimage import io
 from pathlib import Path
 import torch
+import spconv
+
 from pcdet.utils import box_utils, object3d_utils, calibration, common_utils
 from pcdet.ops.roiaware_pool3d import roiaware_pool3d_utils
 from pcdet.config import cfg
 from pcdet.datasets.data_augmentation.dbsampler import DataBaseSampler
-from spconv.utils import VoxelGeneratorV2
 from pcdet.datasets import DatasetTemplate
 
 
@@ -392,11 +393,26 @@ class KittiDataset(BaseKittiDataset):
             )
 
         voxel_generator_cfg = cfg.DATA_CONFIG.VOXEL_GENERATOR
-        self.voxel_generator = VoxelGeneratorV2(
-            voxel_size=voxel_generator_cfg.VOXEL_SIZE,
-            point_cloud_range=cfg.DATA_CONFIG.POINT_CLOUD_RANGE,
-            max_num_points=voxel_generator_cfg.MAX_POINTS_PER_VOXEL
-        )
+        # Support spconv 1.0 and 1.1
+
+        points = np.zeros((1, 3))
+        try:
+            self.voxel_generator = spconv.utils.VoxelGenerator(
+                voxel_size=voxel_generator_cfg.VOXEL_SIZE,
+                point_cloud_range=cfg.DATA_CONFIG.POINT_CLOUD_RANGE,
+                max_num_points=voxel_generator_cfg.MAX_POINTS_PER_VOXEL,
+                max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS
+            )
+            voxels, coordinates, num_points = self.voxel_generator.generate(points)
+        except:
+            self.voxel_generator = spconv.utils.VoxelGeneratorV2(
+                voxel_size=voxel_generator_cfg.VOXEL_SIZE,
+                point_cloud_range=cfg.DATA_CONFIG.POINT_CLOUD_RANGE,
+                max_num_points=voxel_generator_cfg.MAX_POINTS_PER_VOXEL,
+                max_voxels=cfg.DATA_CONFIG[self.mode].MAX_NUMBER_OF_VOXELS
+            )
+            voxel_grid = self.voxel_generator.generate(points)
+
 
     def __len__(self):
         return len(self.kitti_infos)

--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -392,7 +392,7 @@ class KittiDataset(BaseKittiDataset):
             )
 
         voxel_generator_cfg = cfg.DATA_CONFIG.VOXEL_GENERATOR
-        self.voxel_generator = VoxelGenerator(
+        self.voxel_generator = VoxelGeneratorV2(
             voxel_size=voxel_generator_cfg.VOXEL_SIZE,
             point_cloud_range=cfg.DATA_CONFIG.POINT_CLOUD_RANGE,
             max_num_points=voxel_generator_cfg.MAX_POINTS_PER_VOXEL

--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -393,8 +393,8 @@ class KittiDataset(BaseKittiDataset):
             )
 
         voxel_generator_cfg = cfg.DATA_CONFIG.VOXEL_GENERATOR
-        # Support spconv 1.0 and 1.1
 
+        # Support spconv 1.0 and 1.1
         points = np.zeros((1, 3))
         try:
             self.voxel_generator = spconv.utils.VoxelGenerator(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 torch>=1.1
-spconv==1.0
+spconv==1.1
 numba
 tensorboardX
 easydict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 torch>=1.1
-spconv==1.1
+spconv
 numba
 tensorboardX
 easydict

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         install_requires=[
             'numpy',
             'torch>=1.1',
-            'spconv,
+            'spconv',
             'numba',
             'tensorboardX',
             'easydict',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         install_requires=[
             'numpy',
             'torch>=1.1',
-            'spconv==1.0',
+            'spconv==1.1',
             'numba',
             'tensorboardX',
             'easydict',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         install_requires=[
             'numpy',
             'torch>=1.1',
-            'spconv==1.1',
+            'spconv,
             'numba',
             'tensorboardX',
             'easydict',


### PR DESCRIPTION
- Updated `dataset.py` and `kitti_dataset.py` to use `VoxelGeneratorV2`
- Updated `requirements.txt` and `setup.py` to specify `spconv==1.1`
- Tested PointPillars with results:
```
Car AP@0.70, 0.70, 0.70:
bbox AP:90.7802, 89.5710, 88.1988
bev  AP:90.0862, 87.3121, 83.9497
3d   AP:87.3674, 77.2977, 74.0227
aos  AP:90.75, 89.37, 87.89
Car AP_R40@0.70, 0.70, 0.70:
bbox AP:95.9010, 92.0908, 90.7773
bev  AP:94.1856, 88.3521, 85.4229
3d   AP:88.3821, 78.4251, 74.9309
aos  AP:95.87, 91.86, 90.43
Car AP@0.70, 0.50, 0.50:
bbox AP:90.7802, 89.5710, 88.1988
bev  AP:95.3721, 90.0208, 89.1257
3d   AP:95.3044, 89.9037, 88.8997
aos  AP:90.75, 89.37, 87.89
Car AP_R40@0.70, 0.50, 0.50:
bbox AP:95.9010, 92.0908, 90.7773
bev  AP:97.2666, 94.5944, 93.5978
3d   AP:97.2260, 94.2424, 92.9334
aos  AP:95.87, 91.86, 90.43
Pedestrian AP@0.50, 0.50, 0.50:
bbox AP:60.3184, 57.2768, 54.1461
bev  AP:55.1695, 50.0249, 46.1048
3d   AP:50.5018, 45.4544, 41.0912
aos  AP:42.50, 40.33, 37.97
Pedestrian AP_R40@0.50, 0.50, 0.50:
bbox AP:60.1178, 56.4277, 53.1250
bev  AP:54.5183, 48.7809, 44.7121
3d   AP:49.0521, 43.7786, 39.1144
aos  AP:39.67, 36.77, 34.45
Pedestrian AP@0.50, 0.25, 0.25:
bbox AP:60.3184, 57.2768, 54.1461
bev  AP:66.3091, 63.0741, 59.7845
3d   AP:66.2020, 62.4316, 59.2472
aos  AP:42.50, 40.33, 37.97
Pedestrian AP_R40@0.50, 0.25, 0.25:
bbox AP:60.1178, 56.4277, 53.1250
bev  AP:66.7191, 62.8219, 59.4442
3d   AP:66.3862, 62.2832, 58.9252
aos  AP:39.67, 36.77, 34.45
Cyclist AP@0.50, 0.50, 0.50:
bbox AP:84.5649, 71.6686, 68.0017
bev  AP:81.5557, 64.4501, 61.8452
3d   AP:79.1085, 62.6828, 59.1882
aos  AP:84.28, 69.90, 66.25
Cyclist AP_R40@0.50, 0.50, 0.50:
bbox AP:87.6933, 72.7717, 68.6119
bev  AP:83.3776, 65.4307, 61.4462
3d   AP:80.3914, 62.6057, 58.7745
aos  AP:87.36, 70.83, 66.62
Cyclist AP@0.50, 0.25, 0.25:
bbox AP:84.5649, 71.6686, 68.0017
bev  AP:83.6275, 69.9468, 65.7707
3d   AP:83.6275, 69.8436, 65.7707
aos  AP:84.28, 69.90, 66.25
Cyclist AP_R40@0.50, 0.25, 0.25:
bbox AP:87.6933, 72.7717, 68.6119
bev  AP:86.7431, 70.6220, 66.3741
3d   AP:86.7431, 70.5932, 66.3730
aos  AP:87.36, 70.83, 66.62
```
